### PR TITLE
chore(deps): enable Renovate digest pinning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,6 @@
   "minimumReleaseAge": "3 days",
   "semanticCommits": "enabled",
   "semanticCommitType": "chore",
-  "semanticCommitScope": "deps"
+  "semanticCommitScope": "deps",
+  "pinDigests": true
 }


### PR DESCRIPTION
Adds `pinDigests: true` to renovate.json so the base image gets pinned to (and kept in sync with) a digest, matching the beerfen-infra setup.