### PR TITLE
chore: skip release age gate for digest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,12 @@
   "semanticCommits": "enabled",
   "semanticCommitType": "chore",
   "semanticCommitScope": "deps",
-  "pinDigests": true
+  "pinDigests": true,
+  "packageRules": [
+    {
+      "description": "Digest updates have no release timestamp, so minimumReleaseAge can never be satisfied and renovate/stability-days stays pending forever.",
+      "matchUpdateTypes": ["digest", "pinDigest"],
+      "minimumReleaseAge": null
+    }
+  ]
 }


### PR DESCRIPTION
## Problem

`renovate/stability-days` is stuck `pending` forever on digest-update PRs, blocking them permanently rather than temporarily.

`minimumReleaseAge: "3 days"` is evaluated against a release timestamp from the datasource. A bare digest has no release associated with it, so Renovate cannot compute an age and the check never satisfies.

Evidence from the weekend run on 2026-08-02, which set all four statuses in one pass:

| PR | Update type | Target age | `stability-days` |
|---|---|---|---|
| #247 vite v8.2.0 | version | — | SUCCESS |
| #246 login-action v4.6.0 | version | — | SUCCESS |
| #243 nginx digest | digest | ? | pending |
| #242 checkout digest | digest | 16 days | pending |

The split falls exactly along update type. #242 targeted `actions/checkout@3d3c42e`, committed `2026-07-17T18:45:11Z` — 16 days against a 3 day requirement. On both stuck branches the status `updated_at` matched the branch commit time to within 4 seconds, so the status was written once at branch creation and never re-evaluated.

## Change

Exempt `digest` and `pinDigest` updates from `minimumReleaseAge`. Version updates keep the 3 day soak.

Since `pinDigests: true` is enabled, every future digest bump would otherwise hit the same trap.

## Verification

`renovate-config-validator` passes.